### PR TITLE
Add SwiftUI package skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+.DS_Store
+/.build
+/Packages
+xcuserdata/
+DerivedData/
+.swiftpm/configuration/registries.json
+.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+.netrc

--- a/LoyaltyApp/ContentView.swift
+++ b/LoyaltyApp/ContentView.swift
@@ -1,0 +1,12 @@
+import SwiftUI
+
+struct ContentView: View {
+    var body: some View {
+        Text("Welcome to Loyalty App")
+            .padding()
+    }
+}
+
+#Preview {
+    ContentView()
+}

--- a/LoyaltyApp/LoyaltyAppApp.swift
+++ b/LoyaltyApp/LoyaltyAppApp.swift
@@ -1,0 +1,10 @@
+import SwiftUI
+
+@main
+struct LoyaltyAppApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,18 @@
+// swift-tools-version: 6.1
+import PackageDescription
+
+let package = Package(
+    name: "LoyaltyApp",
+    platforms: [
+        .iOS("18.0")
+    ],
+    products: [
+        .executable(name: "LoyaltyApp", targets: ["LoyaltyApp"])
+    ],
+    targets: [
+        .executableTarget(
+            name: "LoyaltyApp",
+            path: "LoyaltyApp"
+        )
+    ]
+)

--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
-# loyalty-app-v2
+# Loyalty App
+
+This repository contains a minimal SwiftUI application skeleton targeting iOS 18. The project is structured as a Swift Package so it can be opened directly in Xcode.
+
+## Getting Started
+
+1. Open `Package.swift` in Xcode 18 or later.
+2. Xcode will generate an iOS application project from the package.
+3. Build and run on the iOS 18 simulator or a device.
+
+The app includes a single `ContentView` presented from `LoyaltyAppApp`.


### PR DESCRIPTION
## Summary
- add a Swift Package containing `LoyaltyApp` with an entry point and `ContentView`
- document how to open the package in Xcode 18

## Testing
- `swift build` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_684a06bf941083328ea416e86c6aafac