### PR TITLE
Add third-party libraries

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -9,9 +9,19 @@ let package = Package(
     products: [
         .executable(name: "LoyaltyApp", targets: ["LoyaltyApp"])
     ],
+    dependencies: [
+        .package(url: "https://github.com/BlockchainCommons/QRCodeGenerator", from: "3.0.1"),
+        .package(url: "https://github.com/kishikawakatsumi/KeychainAccess", from: "4.2.2"),
+        .package(url: "https://github.com/CombineCommunity/CombineExt", from: "1.8.1")
+    ],
     targets: [
         .executableTarget(
             name: "LoyaltyApp",
+            dependencies: [
+                "QRCodeGenerator",
+                "KeychainAccess",
+                "CombineExt"
+            ],
             path: "LoyaltyApp"
         )
     ]


### PR DESCRIPTION
## Summary
- add QRCodeGenerator, KeychainAccess and CombineExt as dependencies

## Testing
- `swift build` *(fails: no such module 'Darwin')*

------
https://chatgpt.com/codex/tasks/task_e_684a07dd7bac833290191696d9c7ca26