### PR TITLE
Fix README instructions for Xcode project

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,10 @@
 # Loyalty App
 
-This repository contains a minimal SwiftUI application skeleton targeting iOS 18. The project is structured as a Swift Package so it can be opened directly in Xcode.
+This repository contains a minimal SwiftUI application skeleton targeting iOS 18. The project is provided as a regular Xcode project so you can open it directly in Xcode.
 
 ## Getting Started
 
-1. Open `Package.swift` in Xcode 18 or later.
-2. Xcode will generate an iOS application project from the package.
-3. Build and run on the iOS 18 simulator or a device.
+1. Open `Loyalty App.xcodeproj` in Xcode 18 or later.
+2. Build and run on the iOS 18 simulator or a device.
 
 The app includes a single `ContentView` presented from `LoyaltyAppApp`.


### PR DESCRIPTION
## Summary
- clarify that the app is an Xcode project rather than a Swift package
- update the setup instructions accordingly

## Testing
- `swift build` *(fails: Could not find Package.swift)*
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_684a20c854e48332b86a5d3ca579e77c