### PR TITLE
Add Swift Package manifest

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,14 @@
+{
+  "pins" : [
+    {
+      "identity" : "keychainaccess",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/kishikawakatsumi/KeychainAccess.git",
+      "state" : {
+        "revision" : "84e546727d66f1adc5439debad16270d0fdd04e7",
+        "version" : "4.2.2"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,25 @@
+// swift-tools-version: 5.9
+import PackageDescription
+
+let package = Package(
+    name: "LoyaltyApp",
+    platforms: [.iOS(.v14)],
+    products: [
+        .library(
+            name: "LoyaltyApp",
+            targets: ["LoyaltyApp"]
+        )
+    ],
+    dependencies: [
+        .package(url: "https://github.com/kishikawakatsumi/KeychainAccess.git", .exact("4.2.2"))
+    ],
+    targets: [
+        .target(
+            name: "LoyaltyApp",
+            dependencies: [
+                .product(name: "KeychainAccess", package: "KeychainAccess")
+            ],
+            path: "LoyaltyApp"
+        )
+    ]
+)


### PR DESCRIPTION
## Summary
- add Swift Package manifest for SPM build

## Testing
- `swift build` *(fails: no such module 'Security')*

------
https://chatgpt.com/codex/tasks/task_e_684acf0c18e48332b5f06f85b0075ad9