### PR TITLE
Add LoginView with sign-in flow

### DIFF
--- a/LoyaltyApp/LoginView.swift
+++ b/LoyaltyApp/LoginView.swift
@@ -1,0 +1,49 @@
+import Foundation
+import SwiftUI
+
+struct LoginView: View {
+    @State private var email: String = ""
+    @State private var showAlert: Bool = false
+    @State private var alertMessage: String = ""
+    @State private var navigate: Bool = false
+
+    var body: some View {
+        NavigationStack {
+            VStack(spacing: 20) {
+                TextField("Email", text: $email)
+                    .textFieldStyle(.roundedBorder)
+                    .keyboardType(.emailAddress)
+                Button("Sign In") {
+                    signIn()
+                }
+                NavigationLink(destination: LoyaltyView(), isActive: $navigate) { EmptyView() }
+            }
+            .padding()
+            .alert("Error", isPresented: $showAlert) {
+                Button("OK", role: .cancel) {}
+            } message: {
+                Text(alertMessage)
+            }
+        }
+    }
+
+    private func signIn() {
+        GoodtillAPI.signIn(email: email) { result in
+            DispatchQueue.main.async {
+                switch result {
+                case .success(let token):
+                    KeychainManager.saveEmail(email)
+                    KeychainManager.saveToken(token, date: Date())
+                    navigate = true
+                case .failure(let error):
+                    alertMessage = error.localizedDescription
+                    showAlert = true
+                }
+            }
+        }
+    }
+}
+
+#Preview {
+    LoginView()
+}


### PR DESCRIPTION
## Summary
- add new `LoginView` with email field, sign in button, and navigation to `LoyaltyView`
- integrate `GoodtillAPI.signIn` and `KeychainManager` for token storage
- show alert on sign in failure

## Testing
- `swift test` *(fails: no such module 'Security')*

------
https://chatgpt.com/codex/tasks/task_e_684ad1fbcc588332894ee088c26e888e