### PR TITLE
Add NetworkClient for authenticated requests

### DIFF
--- a/Networking/NetworkClient.swift
+++ b/Networking/NetworkClient.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+enum NetworkError: Error {
+    case notAuthenticated
+}
+
+struct NetworkClient {
+    let baseURL: URL
+
+    func buildRequest(endpoint: String) throws -> URLRequest {
+        guard let (token, _) = KeychainManager.getToken() else {
+            throw NetworkError.notAuthenticated
+        }
+        let url = baseURL.appendingPathComponent(endpoint)
+        var request = URLRequest(url: url)
+        request.addValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        return request
+    }
+}


### PR DESCRIPTION
## Summary
- create `Networking` directory and add `NetworkClient` implementation
- define `NetworkError` and authenticated request builder

## Testing
- `swift test` *(fails: no such module 'Security')*

------
https://chatgpt.com/codex/tasks/task_e_684ad304869c8332ab4fb04cba4da43d