### PR TITLE
Update LoginView to use MainActor

### DIFF
--- a/LoyaltyApp/LoginView.swift
+++ b/LoyaltyApp/LoginView.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SwiftUI
 
 struct LoginView: View {
@@ -27,18 +26,17 @@ struct LoginView: View {
         }
     }
 
+    @MainActor
     private func signIn() {
         GoodtillAPI.signIn(email: email) { result in
-            DispatchQueue.main.async {
-                switch result {
-                case .success(let token):
-                    KeychainManager.saveEmail(email)
-                    KeychainManager.saveToken(token, date: Date())
-                    navigate = true
-                case .failure(let error):
-                    alertMessage = error.localizedDescription
-                    showAlert = true
-                }
+            switch result {
+            case .success(let token):
+                KeychainManager.saveEmail(email)
+                KeychainManager.saveToken(token, date: Date())
+                navigate = true
+            case .failure(let error):
+                alertMessage = error.localizedDescription
+                showAlert = true
             }
         }
     }


### PR DESCRIPTION
## Summary
- update `LoginView` imports
- mark `signIn()` with `@MainActor`
- update sign in flow to modify state directly

## Testing
- `swift test -l` *(fails: no such module 'Security')*

------
https://chatgpt.com/codex/tasks/task_e_684ada618b608332a6bf7ae67dd3e280