### PR TITLE
Fix navigation deprecation in LoginView

### DIFF
--- a/LoyaltyApp/LoginView.swift
+++ b/LoyaltyApp/LoginView.swift
@@ -15,13 +15,15 @@ struct LoginView: View {
                 Button("Sign In") {
                     signIn()
                 }
-                NavigationLink(destination: LoyaltyView(), isActive: $navigate) { EmptyView() }
             }
             .padding()
             .alert("Error", isPresented: $showAlert) {
                 Button("OK", role: .cancel) {}
             } message: {
                 Text(alertMessage)
+            }
+            .navigationDestination(isPresented: $navigate) {
+                LoyaltyView()
             }
         }
     }


### PR DESCRIPTION
## Summary
- update `LoginView` to use `navigationDestination` instead of deprecated `NavigationLink`

## Testing
- `swift build` *(fails: no such module 'Security')*
- `swift test` *(fails: no such module 'Security')*

------
https://chatgpt.com/codex/tasks/task_e_684aec1086548332bed95c850dc081ae