### PR TITLE
Include Networking module

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -15,8 +15,13 @@ let package = Package(
     ],
     targets: [
         .target(
+            name: "Networking",
+            path: "Networking"
+        ),
+        .target(
             name: "LoyaltyApp",
             dependencies: [
+                "Networking",
                 .product(name: "KeychainAccess", package: "KeychainAccess")
             ],
             path: "LoyaltyApp"


### PR DESCRIPTION
## Summary
- fix missing `NetworkClient` by adding a `Networking` target
- wire the new module into the `LoyaltyApp` target

## Testing
- `swift build` *(fails: error: expressions are not allowed at the top level)*

------
https://chatgpt.com/codex/tasks/task_e_684aee98b0d08332bc4f9c2bde67916a