### PR TITLE
Add KeychainManager unit tests

### DIFF
--- a/LoyaltyAppTests/KeychainManagerTests.swift
+++ b/LoyaltyAppTests/KeychainManagerTests.swift
@@ -1,0 +1,18 @@
+import XCTest
+@testable import LoyaltyApp
+
+final class KeychainManagerTests: XCTestCase {
+    func testSaveAndGetEmail() throws {
+        KeychainManager.saveEmail("test@example.com")
+        XCTAssertEqual(KeychainManager.getEmail(), "test@example.com")
+    }
+
+    func testSaveAndGetToken() throws {
+        let date = Date(timeIntervalSince1970: 0)
+        KeychainManager.saveToken("TOKEN123", date: date)
+        let result = KeychainManager.getToken()
+        XCTAssertNotNil(result)
+        XCTAssertEqual(result?.token, "TOKEN123")
+        XCTAssertEqual(result?.date, date)
+    }
+}


### PR DESCRIPTION
## Summary
- add new test case file for KeychainManager

## Testing
- `swift test` *(fails: invalid custom path 'Networking' for target 'Networking')*

------
https://chatgpt.com/codex/tasks/task_e_684b160bf06883328b409dc79f2188cc