### PR TITLE
Add network client test

### DIFF
--- a/LoyaltyAppTests/NetworkClientTests.swift
+++ b/LoyaltyAppTests/NetworkClientTests.swift
@@ -1,0 +1,22 @@
+import XCTest
+@testable import LoyaltyApp
+
+final class NetworkClientTests: XCTestCase {
+    func testBuildRequestAddsAuthorizationHeader() throws {
+        // Store a fake token so TokenRefresher finds it
+        KeychainManager.saveToken("FAKE_TOKEN", date: Date())
+
+        let expectation = expectation(description: "buildRequest")
+        let client = NetworkClient(baseURL: URL(string: "https://example.com")!)
+        var builtRequest: URLRequest?
+        client.buildRequest(endpoint: "test") { result in
+            builtRequest = try? result.get()
+            expectation.fulfill()
+        }
+        waitForExpectations(timeout: 1)
+
+        let request = try XCTUnwrap(builtRequest)
+        XCTAssertTrue(request.url?.absoluteString.hasSuffix("/test") ?? false)
+        XCTAssertEqual(request.value(forHTTPHeaderField: "Authorization"), "Bearer FAKE_TOKEN")
+    }
+}


### PR DESCRIPTION
## Summary
- add tests for `NetworkClient.buildRequest` to ensure the authorization header includes the saved token

## Testing
- `swift test` *(fails: invalid custom path 'Networking' for target 'Networking')*

------
https://chatgpt.com/codex/tasks/task_e_684b16a34b3483328460d206d9c32a39