### PR TITLE
Add UI test for login flow

### DIFF
--- a/LoyaltyAppUITests/LoginFlowTests.swift
+++ b/LoyaltyAppUITests/LoginFlowTests.swift
@@ -1,0 +1,27 @@
+import XCTest
+
+final class LoginFlowTests: XCTestCase {
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+        let app = XCUIApplication()
+        app.launch()
+    }
+
+    func testLoginAndDisplayLoyaltyFlow() throws {
+        let app = XCUIApplication()
+        let emailField = app.textFields["Email"]
+        XCTAssertTrue(emailField.waitForExistence(timeout: 2))
+        emailField.tap()
+        emailField.typeText("test@example.com")
+
+        app.buttons["Sign In"].tap()
+
+        let ptsLabel = app.staticTexts["You have 750 pts (~£7.50)"]
+        XCTAssertTrue(ptsLabel.waitForExistence(timeout: 2))
+
+        app.buttons["Refresh"].tap()
+
+        XCTAssertTrue(ptsLabel.exists)
+    }
+}


### PR DESCRIPTION
## Summary
- create `LoginFlowTests` under `LoyaltyAppUITests`
- test sign-in process and loyalty view refresh

## Testing
- `swift test` *(fails: invalid custom path 'Networking' for target 'Networking')*

------
https://chatgpt.com/codex/tasks/task_e_684b540665a48332b9b33d204e1b5ce6