### PR TITLE
Add login UI test and remove example

### DIFF
--- a/LoyaltyAppUITests/LoginFlowTests.swift
+++ b/LoyaltyAppUITests/LoginFlowTests.swift
@@ -1,0 +1,29 @@
+import XCTest
+
+final class LoginFlowTests: XCTestCase {
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+        XCUIApplication().launch()
+    }
+
+    func testLoginAndShowLoyalty() throws {
+        let app = XCUIApplication()
+
+        // 1. Enter email
+        let emailField = app.textFields["Email"]
+        XCTAssertTrue(emailField.waitForExistence(timeout: 2))
+        emailField.tap()
+        emailField.typeText("test@example.com")
+
+        // 2. Tap Sign In
+        app.buttons["Sign In"].tap()
+
+        // 3. Verify loyalty screen
+        let ptsLabel = app.staticTexts["You have 750 pts (~£7.50)"]
+        XCTAssertTrue(ptsLabel.waitForExistence(timeout: 2))
+
+        // 4. Tap Refresh and re-check
+        app.buttons["Refresh"].tap()
+        XCTAssertTrue(ptsLabel.exists)
+    }
+}

--- a/UITestingBundle/UITestingBundle.swift
+++ b/UITestingBundle/UITestingBundle.swift
@@ -22,14 +22,6 @@ final class UITestingBundle: XCTestCase {
         // Put teardown code here. This method is called after the invocation of each test method in the class.
     }
 
-    @MainActor
-    func testExample() throws {
-        // UI tests must launch the application that they test.
-        let app = XCUIApplication()
-        app.launch()
-
-        // Use XCTAssert and related functions to verify your tests produce the correct results.
-    }
 
     @MainActor
     func testLaunchPerformance() throws {


### PR DESCRIPTION
## Summary
- remove obsolete testExample method from UITestingBundle
- add new LoginFlow UI test

## Testing
- `swift test` *(fails: invalid custom path 'Networking')*

------
https://chatgpt.com/codex/tasks/task_e_684b56a8dd8483329b1d0c0286a2a327