### PR TITLE
Add accessibility identifiers to login UI

### DIFF
--- a/LoyaltyApp/LoginView.swift
+++ b/LoyaltyApp/LoginView.swift
@@ -10,11 +10,13 @@ struct LoginView: View {
         NavigationStack {
             VStack(spacing: 20) {
                 TextField("Email", text: $email)
+                    .accessibilityIdentifier("emailField")
                     .textFieldStyle(.roundedBorder)
                     .keyboardType(.emailAddress)
                 Button("Sign In") {
                     signIn()
                 }
+                .accessibilityIdentifier("signInButton")
             }
             .padding()
             .alert("Error", isPresented: $showAlert) {

--- a/LoyaltyAppUITests/LoginFlowTests.swift
+++ b/LoyaltyAppUITests/LoginFlowTests.swift
@@ -10,12 +10,12 @@ final class LoginFlowTests: XCTestCase {
 
     func testLoginAndDisplayLoyaltyFlow() throws {
         let app = XCUIApplication()
-        let emailField = app.textFields["Email"]
+        let emailField = app.textFields["emailField"]
         XCTAssertTrue(emailField.waitForExistence(timeout: 2))
         emailField.tap()
         emailField.typeText("test@example.com")
 
-        app.buttons["Sign In"].tap()
+        app.buttons["signInButton"].tap()
 
         let ptsLabel = app.staticTexts["pointsLabel"]
         XCTAssertTrue(ptsLabel.waitForExistence(timeout: 5))


### PR DESCRIPTION
## Summary
- update `LoginView` text field and button with accessibility identifiers
- use these identifiers in `LoginFlowTests`

## Testing
- `swift test` *(fails: invalid custom path 'Networking' for target)*

------
https://chatgpt.com/codex/tasks/task_e_684b5f9bf72083329e222f5dc693688e