### PR TITLE
Add unit and UI tests

### DIFF
--- a/LoyaltyAppTests/KeychainManagerTests.swift
+++ b/LoyaltyAppTests/KeychainManagerTests.swift
@@ -1,0 +1,20 @@
+import XCTest
+@testable import LoyaltyApp
+
+final class KeychainManagerTests: XCTestCase {
+    func testSaveAndGetEmail() {
+        KeychainManager.saveEmail("user@example.com")
+        XCTAssertEqual(KeychainManager.getEmail(), "user@example.com")
+    }
+
+    func testSaveAndGetToken() {
+        let now = Date()
+        KeychainManager.saveToken("TOKEN123", date: now)
+        let tokenInfo = KeychainManager.getToken()
+        XCTAssertEqual(tokenInfo?.token, "TOKEN123")
+        XCTAssertNotNil(tokenInfo)
+        if let date = tokenInfo?.date {
+            XCTAssertLessThan(abs(date.timeIntervalSince(now)), 1)
+        }
+    }
+}

--- a/LoyaltyAppTests/NetworkClientTests.swift
+++ b/LoyaltyAppTests/NetworkClientTests.swift
@@ -1,0 +1,22 @@
+import XCTest
+@testable import LoyaltyApp
+
+final class NetworkClientTests: XCTestCase {
+    func testBuildRequestInjectsHeaderAndURL() {
+        KeychainManager.saveToken("HEADER_TOKEN", date: Date())
+        let base = URL(string: "https://example.com")!
+        let client = NetworkClient(baseURL: base)
+        let expectation = self.expectation(description: "request")
+        client.buildRequest(endpoint: "path") { result in
+            switch result {
+            case .success(let request):
+                XCTAssertEqual(request.url, base.appendingPathComponent("path"))
+                XCTAssertEqual(request.value(forHTTPHeaderField: "Authorization"), "Bearer HEADER_TOKEN")
+            case .failure(let error):
+                XCTFail("Unexpected error: \(error)")
+            }
+            expectation.fulfill()
+        }
+        waitForExpectations(timeout: 1)
+    }
+}

--- a/LoyaltyAppUITests/LoginFlowTests.swift
+++ b/LoyaltyAppUITests/LoginFlowTests.swift
@@ -1,0 +1,16 @@
+import XCTest
+
+final class LoginFlowTests: XCTestCase {
+    func testLoginFlow() {
+        let app = XCUIApplication()
+        app.launch()
+        let emailField = app.textFields["Email"]
+        XCTAssertTrue(emailField.waitForExistence(timeout: 5))
+        emailField.tap()
+        emailField.typeText("test@example.com")
+        app.buttons["Sign In"].tap()
+        let points = app.staticTexts["pointsLabel"]
+        XCTAssertTrue(points.waitForExistence(timeout: 5))
+        XCTAssertTrue(points.label.contains("pts"))
+    }
+}

--- a/LoyaltyAppUITests/LoyaltyAppUITestsLaunchTests.swift
+++ b/LoyaltyAppUITests/LoyaltyAppUITestsLaunchTests.swift
@@ -1,0 +1,9 @@
+import XCTest
+
+final class LoyaltyAppUITestsLaunchTests: XCTestCase {
+    func testLaunchShowsEmailField() {
+        let app = XCUIApplication()
+        app.launch()
+        XCTAssertTrue(app.textFields["Email"].exists)
+    }
+}


### PR DESCRIPTION
## Summary
- add KeychainManager unit tests
- add NetworkClient unit tests
- add LoginFlow UI test
- add launch UI test

## Testing
- `swift test --enable-test-discovery` *(fails: no such module 'Security')*

------
https://chatgpt.com/codex/tasks/task_e_684c22c61ad08332afe7b2341912a65b